### PR TITLE
Direct buffers

### DIFF
--- a/src/main/java/com/hackoeur/jglm/buffer/BufferAllocatorFactory.java
+++ b/src/main/java/com/hackoeur/jglm/buffer/BufferAllocatorFactory.java
@@ -34,12 +34,12 @@ public class BufferAllocatorFactory {
 	private static class DefaultBufferAllocator implements BufferAllocator {
 		@Override
 		public ByteBuffer allocateByteBuffer(int sizeInBytes) {
-			return ByteBuffer.allocate(sizeInBytes);
+			return ByteBuffer.allocateDirect(sizeInBytes);
 		}
 
 		@Override
 		public FloatBuffer allocateFloatBuffer(int sizeInFloats) {
-			return FloatBuffer.allocate(sizeInFloats);
+			return ByteBuffer.allocateDirect(sizeInFloats << 2).asFloatBuffer();
 		}
 	};
 	

--- a/src/main/java/com/hackoeur/jglm/buffer/BufferAllocatorFactory.java
+++ b/src/main/java/com/hackoeur/jglm/buffer/BufferAllocatorFactory.java
@@ -15,6 +15,7 @@
 package com.hackoeur.jglm.buffer;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.FloatBuffer;
 
 import com.hackoeur.jglm.support.JglmConfig;
@@ -34,12 +35,12 @@ public class BufferAllocatorFactory {
 	private static class DefaultBufferAllocator implements BufferAllocator {
 		@Override
 		public ByteBuffer allocateByteBuffer(int sizeInBytes) {
-			return ByteBuffer.allocateDirect(sizeInBytes);
+			return ByteBuffer.allocateDirect(sizeInBytes).order(ByteOrder.nativeOrder());
 		}
 
 		@Override
 		public FloatBuffer allocateFloatBuffer(int sizeInFloats) {
-			return ByteBuffer.allocateDirect(sizeInFloats << 2).asFloatBuffer();
+			return allocateByteBuffer(sizeInFloats << 2).asFloatBuffer();
 		}
 	};
 	


### PR DESCRIPTION
I switched the buffer allocator factory to allocate direct buffers. These can then be passed to native code directly. Non-direct buffers can't be used by native code, so you'd have to first copy the data into a direct buffer, which seems wasteful, since `getBuffer` already creates a new buffer.